### PR TITLE
Add sxhkd-mode-indentation-length var to set indentation length

### DIFF
--- a/sxhkd-mode.el
+++ b/sxhkd-mode.el
@@ -44,6 +44,9 @@ Can be t, nil or ask"
                 (const :tag "Ask" ask))
   :group 'sxhkd-mode)
 
+(defvar sxhkd-mode-indentation-length 2
+  "Indentation length")
+
 (defvar sxhkd-mode-keywords
   '("super" "hyper" "meta" "alt" "control" "ctrl" "shift" "mode_switch" "lock"
     "mod1" "mod2" "mod3" "mod4" "mod5" "any" "button1" "button2" "button3"
@@ -93,9 +96,9 @@ Can be t, nil or ask"
 
 (defun sxhkd-mode-indent-line ()
   "Indentation function for `sxhkd-mode'."
-  (indent-line-to (sxhkd-mode-indentation-length)))
+  (indent-line-to (sxhkd-mode-current-indentation-length)))
 
-(defun sxhkd-mode-indentation-length ()
+(defun sxhkd-mode-current-indentation-length ()
   "Determine indentation length of current line."
   (save-excursion
     (if (zerop (current-line))
@@ -108,8 +111,8 @@ Can be t, nil or ask"
       (if (looking-at-p (rx (or "#" (and bol eol))))
           0
         (end-of-line)
-        (forward-char -1)
-        (if (looking-at-p (rx "\\")) 0 1)))))
+        (forward-char (* -1 sxhkd-mode-indentation-length))
+        (if (looking-at-p (rx "\\")) 0 sxhkd-mode-indentation-length)))))
 
 ;;;###autoload
 (define-derived-mode sxhkd-mode fundamental-mode "Sxhkd"

--- a/sxhkd-mode.el
+++ b/sxhkd-mode.el
@@ -44,8 +44,10 @@ Can be t, nil or ask"
                 (const :tag "Ask" ask))
   :group 'sxhkd-mode)
 
-(defvar sxhkd-mode-indentation-length 2
-  "Indentation length")
+(defcustom sxhkd-mode-indentation-length 2
+  "Indentation length."
+  :type 'integer
+  :group 'sxhkd-mode)
 
 (defvar sxhkd-mode-keywords
   '("super" "hyper" "meta" "alt" "control" "ctrl" "shift" "mode_switch" "lock"
@@ -111,7 +113,7 @@ Can be t, nil or ask"
       (if (looking-at-p (rx (or "#" (and bol eol))))
           0
         (end-of-line)
-        (forward-char (* -1 sxhkd-mode-indentation-length))
+        (forward-char (- sxhkd-mode-indentation-length))
         (if (looking-at-p (rx "\\")) 0 sxhkd-mode-indentation-length)))))
 
 ;;;###autoload


### PR DESCRIPTION
Added `sxhkd-mode-indentation-length` var to set indentation length.

Renamed `sxhkd-mode-indentation-length` function to `sxhkd-mode-current-indentation-length`.